### PR TITLE
added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+*        text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 
 # General rules
 
-.*
 *.orig
 *.rej
 *.o
@@ -94,3 +93,26 @@ config.log
 
 # Result of make libafs_tree
 /libafs_tree
+
+# Other generated files
+src/audit/.libs/
+src/auth/.libs/
+src/cmd/.libs/
+src/comerr/.libs/
+src/crypto/hcrypto/.libs/
+src/crypto/rfc3961/.libs/
+src/fsint/.libs/
+src/kopenafs/.libs/
+src/libacl/.libs/
+src/libafsrpc/.libs/
+src/lwp/.libs/
+src/opr/.libs/
+src/ptserver/.libs/
+src/roken/.libs/
+src/rx/.libs/
+src/rxkad/.libs/
+src/rxstat/.libs/
+src/sys/.libs/
+src/ubik/.libs/
+src/usd/.libs/
+src/util/.libs/


### PR DESCRIPTION
This will avoid future trouble with line endings (removed `.*` from `.gitignore` and added `autoconf` `.libs` directories explicitly).

There're no issues now, but since there're no changes necessary it's a good idea to do that now better than later.