### PR TITLE
Use designated initializers for RAND_METHOD

### DIFF
--- a/src/crypto/hcrypto/kernel/rand-timer.c
+++ b/src/crypto/hcrypto/kernel/rand-timer.c
@@ -43,12 +43,12 @@ timer_status(void)
 }
 
 const RAND_METHOD hc_rand_timer_method = {
-    timer_seed,
-    timer_bytes,
-    timer_cleanup,
-    timer_add,
-    timer_pseudorand,
-    timer_status
+    .seed       = timer_seed,
+    .bytes      = timer_bytes,
+    .cleanup    = timer_cleanup,
+    .add        = timer_add,
+    .pseudorand = timer_pseudorand,
+    .status     = timer_status
 };
 
 const RAND_METHOD *

--- a/src/external/heimdal/hcrypto/rand-fortuna.c
+++ b/src/external/heimdal/hcrypto/rand-fortuna.c
@@ -640,12 +640,12 @@ fortuna_status(void)
 }
 
 const RAND_METHOD hc_rand_fortuna_method = {
-    fortuna_seed,
-    fortuna_bytes,
-    fortuna_cleanup,
-    fortuna_add,
-    fortuna_pseudorand,
-    fortuna_status
+    .seed       = fortuna_seed,
+    .bytes      = fortuna_bytes,
+    .cleanup    = fortuna_cleanup,
+    .add        = fortuna_add,
+    .pseudorand = fortuna_pseudorand,
+    .status     = fortuna_status
 };
 
 const RAND_METHOD *

--- a/src/external/heimdal/hcrypto/rand-timer.c
+++ b/src/external/heimdal/hcrypto/rand-timer.c
@@ -187,12 +187,12 @@ timer_status(void)
 }
 
 const RAND_METHOD hc_rand_timer_method = {
-    timer_seed,
-    timer_bytes,
-    timer_cleanup,
-    timer_add,
-    timer_pseudorand,
-    timer_status
+    .seed       = timer_seed,
+    .bytes      = timer_bytes,
+    .cleanup    = timer_cleanup,
+    .add        = timer_add,
+    .pseudorand = timer_pseudorand,
+    .status     = timer_status
 };
 
 const RAND_METHOD *


### PR DESCRIPTION
Linux imported Grsecurity's RANDSTRUCT which requires the compiler
to understand struct member types before and after randomization
(to avoid dangerous behaviors such as placing variable length
members in the middle of a struct which can later expand into lower
elements' space).
Convert naive declarations of RAND_METHOD structs to use designated
initializers in order to prevent RANDSTRUCT failing during module
compilation.

Testing: module build no longer fails at for these files under
grsecurity 5.4.14 with RANDSTRUCT enabled. Upstream should fare
similarly.